### PR TITLE
Feat: Create ZIP from directory functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ a number of different options to configure how your ZIP files are created.
 - [Getting Started](#getting-started)
 - [Installation](#installation)
 - [Usage](#usage)
-    - [Create a ZIP with a single file](#createpath-string-options-options)
-    - [Create a ZIP with multiple files](#createbulkpaths-string-options-options)
+    - [Create a ZIP with a single file](#frompathpath-string-options-options)
+    - [Create a ZIP with multiple files](#frompathspaths-string-options-options)
+    - [Create a ZIP from a directory](#fromdirectorypath-string-options-options)
     - [Options](#options)
 - [Tests](#running-tests)
 - [Issues](#issues)
@@ -51,7 +52,7 @@ npm i zipster
 You can create a ZIP file containing a single file or multiple files, set a password or not and configure how you want
 the ZIP to be created.
 
-#### .create(path: string, options: Options)
+#### .fromPath(path: string, options: Options)
 
 Create ZIP file containing a single file
 
@@ -62,16 +63,16 @@ const options: Options = {
 }
 
 const zipster = new Zipster()
-zipster.create(path, options)
+zipster.fromPath(path, options)
   .then((outputPath: string) => console.log({ outputPath }, 'Successfully created ZIP'))
 ```
 
-#### .createBulk(paths: string[], options: Options)
+#### .fromPaths(paths: string[], options: Options)
 
 Create ZIP file containing multiple files
 
 ```typescript
-const path = [
+const paths = [
   '/some/path/to/my/file.txt',
   '/some/path/to/my/file.csv'
 ]
@@ -80,7 +81,22 @@ const options: Options = {
 }
 
 const zipster = new Zipster()
-zipster.createBulk(paths, options)
+zipster.fromPaths(paths, options)
+  .then((outputPath: string) => console.log({ outputPath }, 'Successfully created ZIP'))
+```
+
+#### .fromDirectory(path: string, options: Options)
+
+ZIP all sub-directories at a given path, retaining the folder structure of the sub-directories
+
+```typescript
+const path = '/some/path/to/my/directory'
+const options: Options = {
+  format: Formats.ZIP
+}
+
+const zipster = new Zipster()
+zipster.fromDirectory(path, options)
   .then((outputPath: string) => console.log({ outputPath }, 'Successfully created ZIP'))
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zipster",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "TypeScript library built for Node backends to create ZIP files with password protection",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/Zipster.ts
+++ b/src/Zipster.ts
@@ -14,7 +14,7 @@ class Zipster {
   /**
    * Add a single file to a single ZIP file
    */
-  public create(path: string, options: Options): Promise<string> {
+  public fromPath(path: string, options: Options): Promise<string> {
     const fileParts = new FileParts(path)
 
     const archiveData = {
@@ -52,7 +52,7 @@ class Zipster {
   /**
    * Add multiple files to a single ZIP file
    */
-  public createBulk(paths: string[], options: Options): Promise<string> {
+  public fromPaths(paths: string[], options: Options): Promise<string> {
     const outputLocation = this.getOutputPath(options)
 
     const mapToFileParts = () => paths.map((path: string) => new FileParts(path))

--- a/src/Zipster.ts
+++ b/src/Zipster.ts
@@ -89,6 +89,35 @@ class Zipster {
   }
 
   /**
+   * Create a ZIP containing all files within specified directory
+   */
+  public fromDirectory(path: string, options: Options): Promise<string> {
+    const outputLocation = this.getOutputPath(options)
+
+    const createZip = (): Promise<void> => {
+      const writeStream = fs.createWriteStream(outputLocation)
+
+      const archive = ArchiverFactory.getArchiver(options)
+
+      archive.pipe(writeStream)
+      archive.directory(path, false)
+
+      return archive.finalize()
+    }
+
+    const mapSuccess = (): string => outputLocation
+
+    const tapError = (error: Error): never => {
+      throw new ZipsterError(error.message)
+    }
+
+    return Promise.resolve()
+      .then(createZip)
+      .then(mapSuccess)
+      .catch(tapError)
+  }
+
+  /**
    * Returns the output path configured with specified options or defaults
    */
   private getOutputPath(options: Options): string {

--- a/test/mocks/MockArchiver.ts
+++ b/test/mocks/MockArchiver.ts
@@ -3,7 +3,8 @@ import { SinonSandbox } from 'sinon'
 const mockArchiver = (sandbox: SinonSandbox) => ({
   pipe: sandbox.stub(),
   append: sandbox.stub(),
-  finalize: sandbox.stub()
+  finalize: sandbox.stub(),
+  directory: sandbox.stub()
 })
 
 export { mockArchiver }

--- a/test/unit/src/Zipster.test.ts
+++ b/test/unit/src/Zipster.test.ts
@@ -13,6 +13,7 @@ describe('Zipster', () => {
   const sandbox = createSandbox()
   const defaultFileName = 'xxxx-xxxx-xxxx-xxxx'
   const directory = '/some/path/to/file.txt'
+  const expectedPath = `/some/path/to/${defaultFileName}.zip`
   const options: Options = {
     format: Formats.ZIP
   }
@@ -27,7 +28,7 @@ describe('Zipster', () => {
   let readFileSync: any
   let createWriteStream: any
 
-  let zipper: Zipster
+  let zipster: Zipster
 
   beforeEach(() => {
     archiver = mockArchiver(sandbox)
@@ -40,14 +41,12 @@ describe('Zipster', () => {
     sandbox.stub(uuid, 'v4')
       .returns(defaultFileName as any)
 
-    zipper = new Zipster()
+    zipster = new Zipster()
   })
 
   afterEach(() => sandbox.restore())
 
   describe('#create', () => {
-    const expectedDirectory = `/some/path/to/${defaultFileName}.zip`
-
     beforeEach(() => {
       tmpdir.onFirstCall()
         .returns('/some/path/to')
@@ -75,8 +74,8 @@ describe('Zipster', () => {
       readFileSync.onFirstCall()
         .returns(buffer)
 
-      return zipper.create(directory, options)
-        .should.become(expectedDirectory)
+      return zipster.create(directory, options)
+        .should.become(expectedPath)
     })
 
     it('resolves and calls the dependencies appropriately', () => {
@@ -87,12 +86,12 @@ describe('Zipster', () => {
       readFileSync.onFirstCall()
         .returns(buffer)
 
-      return zipper.create(directory, options)
-        .should.become(expectedDirectory)
+      return zipster.create(directory, options)
+        .should.become(expectedPath)
         .then(() => {
           tmpdir.should.have.callCount(1)
           readFileSync.should.have.been.calledOnceWithExactly(directory)
-          createWriteStream.should.have.been.calledOnceWithExactly(expectedDirectory)
+          createWriteStream.should.have.been.calledOnceWithExactly(expectedPath)
           getArchiver.should.have.been.calledOnceWithExactly(options)
           archiver.pipe.should.have.been.calledOnceWithExactly(stream)
           archiver.append.should.have.been.calledOnceWithExactly(buffer, archiveData)
@@ -107,13 +106,12 @@ describe('Zipster', () => {
       readFileSync.onFirstCall()
         .throws(error)
 
-      return zipper.create(directory, options)
+      return zipster.create(directory, options)
         .should.be.rejectedWith(ZipsterError, error.message)
     })
   })
 
   describe('#createBulk', () => {
-    const expectedDirectory = `/some/path/to/${defaultFileName}.zip`
     const directories = [
       directory,
       '/some/path/to/other.csv'
@@ -142,8 +140,8 @@ describe('Zipster', () => {
     it('resolves with the directory when the file is successfully zipped', () => {
       readFileSync.returns(buffer)
 
-      return zipper.createBulk(directories, options)
-        .should.become(expectedDirectory)
+      return zipster.createBulk(directories, options)
+        .should.become(expectedPath)
     })
 
     it('resolves with the configured directory when the file is successfully zipped', () => {
@@ -158,7 +156,7 @@ describe('Zipster', () => {
 
       readFileSync.returns(buffer)
 
-      return zipper.createBulk(directories, options)
+      return zipster.createBulk(directories, options)
         .should.become(expectedDirectory)
     })
 
@@ -170,21 +168,21 @@ describe('Zipster', () => {
 
       readFileSync.returns(buffer)
 
-      return zipper.createBulk(directories, options)
-        .should.become(expectedDirectory)
+      return zipster.createBulk(directories, options)
+        .should.become(expectedPath)
     })
 
     it('resolves after calling the appropriate dependencies', () => {
       readFileSync.returns(buffer)
 
-      return zipper.createBulk(directories, options)
+      return zipster.createBulk(directories, options)
         .should.be.fulfilled
         .then(() => {
           tmpdir.should.have.callCount(1)
           readFileSync.should.have.callCount(2)
           readFileSync.should.have.been.calledWithExactly(directories[0])
           readFileSync.should.have.been.calledWithExactly(directories[1])
-          createWriteStream.should.have.been.calledOnceWithExactly(expectedDirectory)
+          createWriteStream.should.have.been.calledOnceWithExactly(expectedPath)
           getArchiver.should.have.been.calledOnceWithExactly(options)
           archiver.pipe.should.have.callCount(1)
           archiver.pipe.should.have.been.calledWithExactly(stream)
@@ -199,7 +197,66 @@ describe('Zipster', () => {
       readFileSync.onFirstCall()
         .throws(error)
 
-      return zipper.createBulk(directories, options)
+      return zipster.createBulk(directories, options)
+        .should.be.rejectedWith(ZipsterError, error.message)
+    })
+  })
+
+  describe('#fromDirectory', () => {
+    const path = '/some/path/to/my/directory'
+    const expectedPath = `${path}/${defaultFileName}.zip`
+
+    beforeEach(() => {
+      tmpdir.onFirstCall()
+        .returns(path)
+
+      createWriteStream.onFirstCall()
+        .returns(stream)
+
+      getArchiver.onFirstCall()
+        .returns(archiver)
+
+      archiver.pipe
+        .onFirstCall()
+        .returns()
+
+      archiver.directory
+        .onFirstCall()
+        .returns()
+    })
+
+    it('resolves with the output directory of the zipped directory', () => {
+      archiver.finalize
+        .onFirstCall()
+        .resolves()
+
+      return zipster.fromDirectory(path, options)
+        .should.become(expectedPath)
+    })
+
+    it('resolves and calls dependencies appropriately', () => {
+      archiver.finalize
+        .onFirstCall()
+        .resolves()
+
+      return zipster.fromDirectory(path, options)
+        .should.be.fulfilled
+        .then(() => {
+          tmpdir.should.have.callCount(1)
+          createWriteStream.should.have.been.calledOnceWithExactly(expectedPath)
+          getArchiver.should.have.been.calledOnceWithExactly(options)
+          archiver.pipe.should.have.been.calledOnceWithExactly(stream)
+          archiver.directory.should.have.been.calledOnceWithExactly(path, false)
+          archiver.finalize.should.have.callCount(1)
+        })
+    })
+
+    it('rejects with `ZipsterError` when an error occurs', () => {
+      archiver.finalize
+        .onFirstCall()
+        .rejects(error)
+
+      return zipster.fromDirectory(path, options)
         .should.be.rejectedWith(ZipsterError, error.message)
     })
   })


### PR DESCRIPTION
## Scope

If a user wants to create a ZIP from a directory, this functionality should be provided.

## Work done

1. Create `fromDirectory` functionality to ZIP a directory.
2. Create unit test suite for the new functionality.
3. Refactored naming convention of existing functions.
4. Updated README and bumped package major version.