### PR TITLE
Chore: Update README documentation and Zipster naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ files and pass in a number of different options to configure how your ZIP files 
     - [Create a ZIP with a single file](#frompathpath-string-options-options)
     - [Create a ZIP with multiple files](#frompathspaths-string-options-options)
     - [Create a ZIP from a directory](#fromdirectorypath-string-options-options)
+    - [Create a ZIP with a pattern](#frompatternpath-string-pattern-string-options-options)
     - [Options](#options)
     - [Password Example](#password-example)
 - [Tests](#running-tests)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ files and pass in a number of different options to configure how your ZIP files 
     - [Create a ZIP with a pattern](#frompatternpath-string-pattern-string-options-options)
     - [Options](#options)
     - [Password Example](#password-example)
+    - [Supported Formats](#supported-formats)
 - [Tests](#running-tests)
 - [Issues](#issues)
 - [Contributions](#contributions)
@@ -146,6 +147,11 @@ const zipster = new Zipster()
 zipster.fromPath(path, options)
   .then((outputPath: string) => console.log({ outputPath }, 'Successfully created ZIP'))
 ```
+
+#### Supported Formats
+
+There are currently only two formats that are supported, the `.zip` and `.tar` formats. The `zip` format is the only
+format which supports password protection. The password format is specifically available through the `Formats` enum.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ToeFungi_zipster&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=ToeFungi_zipster)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=ToeFungi_zipster&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=ToeFungi_zipster)
 
-Zipster aims to enable developers to easily create password-protected ZIP files. This library relies on a combination of
-other libraries to function correctly as well as built-in Node functionality.
+Zipster aims to enable developers to rapidly and easily create password-protected ZIP files. With various handy
+functions available to satisfy different use-cases, this promise-based library is built using TypeScript and uses native
+Node functionality and leverages two primary libraries.
 
-Although the core behind Zipster is password-protected ZIP files, you can also create passwordless ZIP files and pass in
-a number of different options to configure how your ZIP files are created.
+Although the fundamental principle behind Zipster is password-protected ZIP files, you can also create unprotected ZIP
+files and pass in a number of different options to configure how your ZIP files are created.
 
 **This project is still in development. Please report any bugs or feature requests as an
 [issue](https://github.com/ToeFungi/zipper/issues/new).**
@@ -32,7 +33,7 @@ a number of different options to configure how your ZIP files are created.
 
 ## Getting Started
 
-This is how to get a copy of this working locally. The only requirement is that Node is installed on the base machine.
+You can get started with cloning the Zipster repository by using the following command:
 
 ```bash
 $ git clone git@github.com:ToeFungi/zipster.git
@@ -42,7 +43,7 @@ $ npm i
 
 ## Installation
 
-Use the following command to install the Zipster:
+Use the following command to install the Zipster package:
 
 ```
 npm i zipster
@@ -50,12 +51,14 @@ npm i zipster
 
 ## Usage
 
-You can create a ZIP file containing a single file or multiple files, set a password or not and configure how you want
-the ZIP to be created.
+There are various ways in which you can create your ZIP file and even more options on how you want it configured. You
+can set a password or not, compress or not, specify patterns to match for zipping files, etc.
+
+Here are some examples of how to use the functionality provided by this package:
 
 #### .fromPath(path: string, options: Options)
 
-Create ZIP file containing a single file
+Create an unprotected ZIP file containing a single specified file
 
 ```typescript
 const path = '/some/path/to/my/file.txt'
@@ -70,7 +73,7 @@ zipster.fromPath(path, options)
 
 #### .fromPaths(paths: string[], options: Options)
 
-Create ZIP file containing multiple files
+Create an unprotected ZIP file containing multiple specified files
 
 ```typescript
 const paths = [
@@ -88,7 +91,7 @@ zipster.fromPaths(paths, options)
 
 #### .fromDirectory(path: string, options: Options)
 
-Creates a ZIP file containing all the sub-directories at a given path, retaining the folder structure of the
+Create an unprotected ZIP file containing all the sub-directories at a given path, retaining the folder structure of the
 sub-directories
 
 ```typescript
@@ -104,7 +107,7 @@ zipster.fromDirectory(path, options)
 
 #### .fromPattern(path: string, pattern: string, options: Options)
 
-Creates a ZIP file containing all the files matching the given pattern at the given path
+Create an unprotected ZIP file containing all the files matching the given pattern at the given path
 
 ```typescript
 const path = '/some/path/to/my/directory'
@@ -129,7 +132,7 @@ zipster.fromPattern(path, pattern, options)
 
 #### Password Example
 
-Create a password-protected ZIP file
+Create a password-protected ZIP file containing the specified file
 
 ```typescript
 const path = '/some/path/to/my/file.txt'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zipster",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TypeScript library built for Node backends to create ZIP files with password protection",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "files",
     "compression",
     "compress",
-    "bulk"
+    "bulk",
+    "pattern",
+    "directory",
+    "promises"
   ],
   "files": [
     "lib",
@@ -57,7 +60,7 @@
     "chai": "4.3.4",
     "chai-as-promised": "7.1.1",
     "mocha": "9.1.3",
-    "nyc": "^15.1.0",
+    "nyc": "15.1.0",
     "sinon": "12.0.1",
     "sinon-chai": "3.7.0",
     "source-map-support": "0.5.20",

--- a/src/Zipster.ts
+++ b/src/Zipster.ts
@@ -5,6 +5,7 @@ import * as uuid from 'uuid'
 import { IOptions } from 'glob'
 import { Archiver } from 'archiver'
 
+import { Formats } from './enums/Formats'
 import { Options } from './types/Options'
 import { FileParts } from './libs/FileParts'
 import { ZipsterError } from './errors/ZipsterError'
@@ -149,10 +150,17 @@ class Zipster {
    * Returns the output path configured with specified options or defaults
    */
   private getOutputPath(options: Options): string {
+    const extensionMap = {
+      [Formats.TAR]: 'tar',
+      [Formats.ZIP]: 'zip',
+      [Formats.ZIP_ENCRYPTED]: 'zip'
+    }
+
+    const extension = extensionMap[options.format]
     const outputName = options.output?.name ?? uuid.v4()
     const outputDirectory = options.output?.path ?? os.tmpdir()
 
-    return `${outputDirectory}/${outputName}.zip`
+    return `${outputDirectory}/${outputName}.${extension}`
   }
 }
 

--- a/src/Zipster.ts
+++ b/src/Zipster.ts
@@ -11,7 +11,7 @@ import { ZipsterError } from './errors/ZipsterError'
 import { ArchiverFactory } from './factories/ArchiverFactory'
 
 /**
- * Zipper facilitates the zipping and protecting of data
+ * Zipster facilitates the zipping and protecting of data
  */
 class Zipster {
   /**

--- a/src/enums/Formats.ts
+++ b/src/enums/Formats.ts
@@ -2,8 +2,9 @@
  * Valid formats for the archiver
  */
 enum Formats {
+  TAR = 'tar',
   ZIP = 'zip',
-  ZIP_ENCRYPTABLE = 'zip-encryptable'
+  ZIP_ENCRYPTED = 'zip-encryptable'
 }
 
 export { Formats }

--- a/src/errors/ZipsterError.ts
+++ b/src/errors/ZipsterError.ts
@@ -1,5 +1,5 @@
 /**
- * Zipper Error is the generic error for the Zipper library
+ * Zipster Error is the generic error for the Zipster library
  */
 class ZipsterError extends Error {
   constructor(message: string) {

--- a/src/factories/ArchiverFactory.ts
+++ b/src/factories/ArchiverFactory.ts
@@ -23,11 +23,11 @@ class ArchiverFactory {
       ...rest
     }
 
-    if (options.format === Formats.ZIP) {
+    if (options.format === Formats.ZIP || options.format === Formats.TAR) {
       return create(options.format, archiverOptions)
     }
 
-    if (options.format === Formats.ZIP_ENCRYPTABLE) {
+    if (options.format === Formats.ZIP_ENCRYPTED) {
       this.registerZipEncryptable()
       return create(options.format, archiverOptions)
     }
@@ -36,8 +36,8 @@ class ArchiverFactory {
   }
 
   private static registerZipEncryptable() {
-    if (!isRegisteredFormat(Formats.ZIP_ENCRYPTABLE)) {
-      registerFormat(Formats.ZIP_ENCRYPTABLE, archiverZipEncryptable)
+    if (!isRegisteredFormat(Formats.ZIP_ENCRYPTED)) {
+      registerFormat(Formats.ZIP_ENCRYPTED, archiverZipEncryptable)
     }
   }
 }

--- a/test/unit/src/Zipster.test.ts
+++ b/test/unit/src/Zipster.test.ts
@@ -254,7 +254,7 @@ describe('Zipster', () => {
 
     it('resolves with the configured output location and name', () => {
       const options: Options = {
-        format: Formats.ZIP_ENCRYPTABLE,
+        format: Formats.ZIP_ENCRYPTED,
         password: 'testing',
         output: {
           path: '/foo/bar',

--- a/test/unit/src/factories/ArchiverFactory.test.ts
+++ b/test/unit/src/factories/ArchiverFactory.test.ts
@@ -40,7 +40,7 @@ describe('ArchiverFactory', () => {
 
     const testCases = [
       {
-        descriptor: 'returns archiver without password',
+        descriptor: 'returns ZIP archiver without password',
         options: {
           format: Formats.ZIP
         } as Options,
@@ -51,9 +51,20 @@ describe('ArchiverFactory', () => {
         }
       },
       {
-        descriptor: 'returns archiver with a password',
+        descriptor: 'returns TAR archiver without password',
         options: {
-          format: Formats.ZIP_ENCRYPTABLE,
+          format: Formats.TAR
+        } as Options,
+        assertions: () => {
+          create.should.have.been.calledOnceWithExactly(Formats.TAR, defaultArchiverOptions)
+          registerFormat.should.have.callCount(0)
+          isRegisteredFormat.should.have.callCount(0)
+        }
+      },
+      {
+        descriptor: 'returns ZIP archiver with a password configured and registers the formatter',
+        options: {
+          format: Formats.ZIP_ENCRYPTED,
           password: 'Foo'
         } as Options,
         setup: () => {
@@ -61,18 +72,18 @@ describe('ArchiverFactory', () => {
             .returns(false)
         },
         assertions: () => {
-          create.should.have.been.calledOnceWithExactly(Formats.ZIP_ENCRYPTABLE, {
+          create.should.have.been.calledOnceWithExactly(Formats.ZIP_ENCRYPTED, {
             ...defaultArchiverOptions,
             password: 'Foo'
           })
-          registerFormat.should.have.been.calledOnceWithExactly(Formats.ZIP_ENCRYPTABLE, archiverZipEncryptable)
-          isRegisteredFormat.should.have.been.calledOnceWithExactly(Formats.ZIP_ENCRYPTABLE)
+          registerFormat.should.have.been.calledOnceWithExactly(Formats.ZIP_ENCRYPTED, archiverZipEncryptable)
+          isRegisteredFormat.should.have.been.calledOnceWithExactly(Formats.ZIP_ENCRYPTED)
         }
       },
       {
-        descriptor: 'returns archiver with a password and does not re-register formatter',
+        descriptor: 'returns archiver with a password configured and does not re-register formatter',
         options: {
-          format: Formats.ZIP_ENCRYPTABLE,
+          format: Formats.ZIP_ENCRYPTED,
           password: 'Foo'
         } as Options,
         setup: () => {
@@ -80,12 +91,12 @@ describe('ArchiverFactory', () => {
             .returns(true)
         },
         assertions: () => {
-          create.should.have.been.calledOnceWithExactly(Formats.ZIP_ENCRYPTABLE, {
+          create.should.have.been.calledOnceWithExactly(Formats.ZIP_ENCRYPTED, {
             ...defaultArchiverOptions,
             password: 'Foo'
           })
           registerFormat.should.have.callCount(0)
-          isRegisteredFormat.should.have.been.calledOnceWithExactly(Formats.ZIP_ENCRYPTABLE)
+          isRegisteredFormat.should.have.been.calledOnceWithExactly(Formats.ZIP_ENCRYPTED)
         }
       }
     ]


### PR DESCRIPTION
## Scope

The README documentation is a bit underwhelming and remnants of the old Zipper name are still in the code.

## Work done

1. Refactor the `Zipper` name to `Zipster`
2. Update README documentation.
3. Implement support for `TAR`.